### PR TITLE
Add support for a key resolver to be supplied instead of a static key

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ AuthEngine.prototype.verifyToken = function (signedToken, keyOrKeyResolver, opti
   var jwtOptions = cloneObject(options);
   delete jwtOptions.async;
   if (typeof signedToken == 'string' || signedToken == null) {
-    (typeof keyOrKeyResolver === 'function' ? keyOrKeyResolver : Promise.resolve(keyOrKeyResolver)).then(function(key) {
+    (typeof keyOrKeyResolver === 'function' ? keyOrKeyResolver(signedToken) : Promise.resolve(keyOrKeyResolver)).then(function(key) {
       if (options.async) {
         jwt.verify(signedToken || '', key, jwtOptions, callback);
       } else {
@@ -38,7 +38,7 @@ AuthEngine.prototype.signToken = function (token, keyOrKeyResolver, options, cal
   options = options || {};
   var jwtOptions = cloneObject(options);
   delete jwtOptions.async;
-  (typeof keyOrKeyResolver === 'function' ? keyOrKeyResolver : Promise.resolve(keyOrKeyResolver)).then(function(key) {
+  (typeof keyOrKeyResolver === 'function' ? keyOrKeyResolver(token) : Promise.resolve(keyOrKeyResolver)).then(function(key) {
     if (options.async) {
       jwt.sign(token, key, jwtOptions, callback);
     } else {


### PR DESCRIPTION
This is useful for multi-tenancy, where it is necessary to switch the public key that is used to verify tokens depending on e.g the issuer of the token.